### PR TITLE
Feature/configurable purge prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,15 @@ Target-repo is interpreted Github-style: `[user/]repo` (i.e. `git-kit` or `bsand
 
 #### `purge [prefix [remote]]`
 
-Find and delete all branches with a given prefix that have been merged in the current HEAD. Also finds and deletes these branches from the given (or default) remote
+Find and delete all branches with a given prefix that have been merged in the current HEAD. Also finds and deletes these branches from the given (or default) remote.
 
-`prefix` will default to the regexp `(feature|release|hotfix)/` when not supplied. Using an empty string `""` as prefix will disable it and purge all branches that have been merged into the current HEAD.
+`prefix` will default to the regexp found in git config under key `gitkit.purgeableprefix`. When no config is supplied, `(feature|release|hotfix)/` will be used. Using an empty string `""` as prefix will disable it and purge all branches that have been merged into the current HEAD.
+
+In order to set the `gitkit.prugeableprefix` config use the following command:
+
+```bash
+git config --global gitkit.purgeableprefix "\(feature\|release\|hotfix\|bugfix\)"
+```
 
 #### `purge-remote [prefix [remote]]`
 

--- a/README.md
+++ b/README.md
@@ -106,19 +106,19 @@ Requires presence of the Hub utility: https://hub.github.com/
 
 Target-repo is interpreted Github-style: `[user/]repo` (i.e. `git-kit` or `bsander/git-kit`)
 
-#### `purge [prefix [remote]]`
+#### `purge [remote [prefix]]`
 
 Find and delete all branches with a given prefix that have been merged in the current HEAD. Also finds and deletes these branches from the given (or default) remote.
 
-`prefix` will default to the regexp found in git config under key `gitkit.purgeableprefix`. When no config is supplied, `(feature|release|hotfix)/` will be used. Using an empty string `""` as prefix will disable it and purge all branches that have been merged into the current HEAD.
+`prefix` will default to the regexp found in git config under key `kit.purgeableprefix`. When no config is supplied, `(feature|release|hotfix)/` will be used. Using an empty string `""` as prefix will disable it and purge all branches that have been merged into the current HEAD.
 
-In order to set the `gitkit.prugeableprefix` config use the following command:
+In order to set the `kit.purgeableprefix` config use the following command:
 
 ```bash
-git config --global gitkit.purgeableprefix "\(feature\|release\|hotfix\|bugfix\)"
+git config --global kit.purgeableprefix "\(feature\|release\|hotfix\|bugfix\)"
 ```
 
-#### `purge-remote [prefix [remote]]`
+#### `purge-remote [remote [prefix]]`
 
 Same as `purge`, but uses a remote branch as reference. Useful when your co-workers fail to clean up after themselves.
 

--- a/bin/git-purge
+++ b/bin/git-purge
@@ -12,10 +12,11 @@ BASE_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 
 REMOTE=$(git select-remote "$2" 2>/dev/null || :)
+BRANCH_PREFIX=$(git config --get gitkit.purgeableprefix || echo \(feature\|release\|hotfix\))
 # Don't use :- on $1 to disable the prefix check when passing ""
 # Also, the grep is for an actual asterisk (*) character, not a wildcard or regex.
 # This signifies the current branch.
-BRANCHES=$(git branch --merged | grep -v "^\\*" | grep "^\s*${1-\(feature\|release\|hotfix\)/}" || :)
+BRANCHES=$(git branch --merged | grep -v "^\\*" | grep "^\s*${1-BRANCH_PREFIX/}" || :)
 [[ $BRANCHES ]] || {
   echo "No purgable branches found within $(git current-branch) branch"
   exit 0

--- a/bin/git-purge
+++ b/bin/git-purge
@@ -11,12 +11,12 @@ BASE_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 . "$BASE_DIR/functions.sh"
 
 
-REMOTE=$(git select-remote "$2" 2>/dev/null || :)
-BRANCH_PREFIX=$(git config --get gitkit.purgeableprefix || echo \(feature\|release\|hotfix\))
-# Don't use :- on $1 to disable the prefix check when passing ""
+REMOTE=$(git select-remote "$1" 2>/dev/null || :)
+BRANCH_PREFIX=$(git config --get kit.purgeableprefix || echo \(feature\|release\|hotfix\))
+# Don't use :- on $2 to disable the prefix check when passing ""
 # Also, the grep is for an actual asterisk (*) character, not a wildcard or regex.
 # This signifies the current branch.
-BRANCHES=$(git branch --merged | grep -v "^\\*" | grep "^\s*${1-BRANCH_PREFIX/}" || :)
+BRANCHES=$(git branch --merged | grep -v "^\\*" | grep "^\s*${2-BRANCH_PREFIX/}" || :)
 [[ $BRANCHES ]] || {
   echo "No purgable branches found within $(git current-branch) branch"
   exit 0

--- a/bin/git-purge
+++ b/bin/git-purge
@@ -16,7 +16,7 @@ BRANCH_PREFIX=$(git config --get kit.purgeableprefix || echo \(feature\|release\
 # Don't use :- on $2 to disable the prefix check when passing ""
 # Also, the grep is for an actual asterisk (*) character, not a wildcard or regex.
 # This signifies the current branch.
-BRANCHES=$(git branch --merged | grep -v "^\\*" | grep "^\s*${2-BRANCH_PREFIX/}" || :)
+BRANCHES=$(git branch --merged | grep -v "^\\*" | grep "^\s*${2-$BRANCH_PREFIX/}" || :)
 [[ $BRANCHES ]] || {
   echo "No purgable branches found within $(git current-branch) branch"
   exit 0

--- a/bin/git-purge-remote
+++ b/bin/git-purge-remote
@@ -19,7 +19,7 @@ BRANCH_PREFIX=$(git config --get kit.purgeableprefix || echo \(feature\|release\
 REMOTE_BRANCHES=$(git branch --remotes --merged |
   grep -v "^\\s*${REMOTE}/HEAD ->" | # ignore HEAD reference
   grep -v "^\\s*${REMOTE}/${HEAD}" | # ignore actual HEAD branch
-  grep "^\s*$REMOTE/${2-BRANCH_PREFIX}" | # keep topic branches
+  grep "^\s*$REMOTE/${2-$BRANCH_PREFIX}" | # keep topic branches
   sed "s/\s*$REMOTE\\///" || :) # drop remote prefix
 [[ $REMOTE_BRANCHES ]] || {
   echo "No remote purgable branches found within $(git current-branch) branch"

--- a/bin/git-purge-remote
+++ b/bin/git-purge-remote
@@ -10,15 +10,16 @@ done
 BASE_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 . "$BASE_DIR/functions.sh"
 
-REMOTE=$(git select-remote "$2")
-HEAD=$(git select-branch "" "$2")
-# Don't use :- on $1 to disable the prefix check when passing ""
+REMOTE=$(git select-remote "$1")
+HEAD=$(git select-branch "" "$1")
+BRANCH_PREFIX=$(git config --get kit.purgeableprefix || echo \(feature\|release\|hotfix\))
+# Don't use :- on $2 to disable the prefix check when passing ""
 # Also, the grep is for an actual asterisk (*) character, not a wildcard or regex.
 # This signifies the current branch.
 REMOTE_BRANCHES=$(git branch --remotes --merged |
   grep -v "^\\s*${REMOTE}/HEAD ->" | # ignore HEAD reference
   grep -v "^\\s*${REMOTE}/${HEAD}" | # ignore actual HEAD branch
-  grep "^\s*$REMOTE/${1-\(feature\|release\|hotfix\)/}" | # keep topic branches
+  grep "^\s*$REMOTE/${2-BRANCH_PREFIX}" | # keep topic branches
   sed "s/\s*$REMOTE\\///" || :) # drop remote prefix
 [[ $REMOTE_BRANCHES ]] || {
   echo "No remote purgable branches found within $(git current-branch) branch"

--- a/bin/git-sync
+++ b/bin/git-sync
@@ -40,6 +40,4 @@ git current-branch "$HEAD" || (set -x; git checkout -q "$HEAD")
 }
 
 # Cleanup
-set -x
-BRANCH_PREFIX=$(git config --get gitkit.purgeableprefix || echo \(feature\|release\|hotfix\))
-git purge "$BRANCH_PREFIX/" "$REMOTE"
+git purge "$REMOTE"

--- a/bin/git-sync
+++ b/bin/git-sync
@@ -40,4 +40,6 @@ git current-branch "$HEAD" || (set -x; git checkout -q "$HEAD")
 }
 
 # Cleanup
-git purge "\(feature\|release\|hotfix\)/" "$REMOTE"
+set -x
+BRANCH_PREFIX=$(git config --get gitkit.purgeableprefix || echo \(feature\|release\|hotfix\))
+git purge "$BRANCH_PREFIX/" "$REMOTE"


### PR DESCRIPTION
### Context
Since Hilverda contained many branches starting with `bugfix/`, I wanted to make sure all merged branches were purged. In order to make this happen, I found out the regexp for both `git sync` and `git purge` was hard-coded, so I decided to make that configurable.

### What has been done?
- Use `kit.purgeableprefix` to determine the prefix to use for `purge`
- Change order of parameters passed to both `git purge` and `git purge-remote`, to make sure the purgeable prefix default is only determined within `purge` itself (before this, the logic was also in `git sync`)
- Update `README.md`

### How to test?
- First, put `set -x` in `git-purge` to check commands that are being run
- Let's verify final fallback still works. Without setting any config, run `git purge` in whatever branch. Verify final fallback `(feature|release|hotfix)/` is used
- Now, set a config var like `git config --global kit.purgeableprefix "\(feature\|release\|hotfix\|bugfix\)"` and run `git purge`. Verify `bugfix` is added to purge command
- Now, with the config set, run `git purge origin foobar` and verify `foobar` is used as prefix.